### PR TITLE
Avoid errors with STATE variables without DERIVATE block

### DIFF
--- a/README.html
+++ b/README.html
@@ -91,5 +91,17 @@ List of main files
 For any questions or further assistance please contact:
 salvadordura at gmail.com
 
+
+------------------------------------------------------------------------------------------------------
+Changelog
+-------------------------------------------------------------------------------------------------------
+
+2022-05:
+  * Updated MOD files to compile with upcoming 9.0 neuron release
+    with migration to C++.
+  * izhi2007.mod is updated in order to compile with current neuron
+    releases where STATE variables without ODEs or SOLVE block gives an error.
+    See discussion in https://github.com/ModelDBRepository/194897/pull/2
+
 </pre></html>
 

--- a/izhi2007.mod
+++ b/izhi2007.mod
@@ -125,9 +125,11 @@ PROCEDURE useverbose() { : Create user-accessible function
 }
 
 
+PROCEDURE states() {}
 
 : Define neuron dynamics
 BREAKPOINT {
+  SOLVE states
   delta = t-t0 : Find time difference
 
   : Receptor dynamics -- the correct form is gAMPA = gAMPA*exp(-delta/tauAMPA), but this is 30% slower and, in the end, not really any more physiologically realistic

--- a/izhi2007.mod
+++ b/izhi2007.mod
@@ -78,13 +78,12 @@ ASSIGNED {
   :t0 : Previous time 
   factor : Voltage factor used for calculating the current
   eventflag : For diagnostic information
-}
 
+  : State variables without ODEs / SOLVE block and hence converted
+  : to ASSIGN. See https://github.com/ModelDBRepository/194897/pull/2
 
-: State variables
-STATE {
-  V (mV) : Membrane voltage
-  u (mV) : Slow current/recovery variable
+  V : Membrane voltage
+  u : Slow current/recovery variable
   gAMPA : AMPA conductance
   gNMDA : NMDA conductance
   gGABAA : GABAA conductance
@@ -125,11 +124,8 @@ PROCEDURE useverbose() { : Create user-accessible function
 }
 
 
-PROCEDURE states() {}
-
 : Define neuron dynamics
 BREAKPOINT {
-  SOLVE states
   delta = t-t0 : Find time difference
 
   : Receptor dynamics -- the correct form is gAMPA = gAMPA*exp(-delta/tauAMPA), but this is 30% slower and, in the end, not really any more physiologically realistic

--- a/nsloc.mod
+++ b/nsloc.mod
@@ -79,8 +79,13 @@ FUNCTION invl(mean (ms)) (ms) {
 	}
 }
 VERBATIM
+#ifndef NRN_VERSION_GTEQ_8_2_0
 double nrn_random_pick(void* r);
 void* nrn_random_arg(int argpos);
+#define RANDCAST
+#else
+#define RANDCAST (Rand*)
+#endif
 ENDVERBATIM
 
 FUNCTION erand() {
@@ -91,7 +96,7 @@ VERBATIM
 		: each instance. However, the corresponding hoc Random
 		: distribution MUST be set to Random.negexp(1)
 		*/
-		_lerand = nrn_random_pick(_p_donotuse);
+		_lerand = nrn_random_pick(RANDCAST _p_donotuse);
 	}else{
 		/* only can be used in main thread */
 		if (_nt != nrn_threads) {

--- a/vecevent.mod
+++ b/vecevent.mod
@@ -32,8 +32,8 @@ NET_RECEIVE (w) {
 
 DESTRUCTOR {
 VERBATIM
-	void* vv = (void*)(_p_ptr);  
-        if (vv) {
+	IvocVect* vv = (IvocVect*)(_p_ptr);
+	if (vv) {
 		hoc_obj_unref(*vector_pobj(vv));
 	}
 ENDVERBATIM
@@ -46,8 +46,8 @@ VERBATIM
 	if (i >= 0) {
 		vv = (void*)(_p_ptr);
 		if (vv) {
-			size = vector_capacity(vv);
-			px = vector_vec(vv);
+			size = vector_capacity((IvocVect*)vv);
+			px = vector_vec((IvocVect*)vv);
 			if (i < size) {
 				etime = px[i];
 				index += 1.;
@@ -65,14 +65,14 @@ ENDVERBATIM
 PROCEDURE play() {
 VERBATIM
 	void** pv;
-	void* ptmp = NULL;
+	IvocVect* ptmp = NULL;
 	if (ifarg(1)) {
 		ptmp = vector_arg(1);
 		hoc_obj_ref(*vector_pobj(ptmp));
 	}
 	pv = (void**)(&_p_ptr);
 	if (*pv) {
-		hoc_obj_unref(*vector_pobj(*pv));
+		hoc_obj_unref(*vector_pobj((IvocVect*)*pv));
 	}
 	*pv = ptmp;
 ENDVERBATIM


### PR DESCRIPTION
 * In case of state variables without ODEs or  SOLVE block we get
   errors like:

   V not really a STATE; Ie. No differential equation for it
   gNMDA not really a STATE; Ie. No differential equation for it

 * Not sure about the "desirable" fix here:

   - should we avoid declaring variables as STATE
   - use workaround of empty SOLVE block like this PR
   - have fix in neuron to avoid this as an error

Tagging @nrnhines for this to discuss.